### PR TITLE
Libvirt: fix libvirt_use_sudo option

### DIFF
--- a/lib/kytoon/providers/libvirt/server_group.rb
+++ b/lib/kytoon/providers/libvirt/server_group.rb
@@ -61,7 +61,7 @@ class ServerGroup
     json_hash=JSON.parse(json)
 
     configs = Util.load_configs
-    use_sudo = ENV['LIBVIRT_USE_SUDO'] || configs['libvirt_use_sudo']
+    use_sudo = ENV['LIBVIRT_USE_SUDO'] || configs['libvirt_use_sudo'].to_s
 
     sg=ServerGroup.new(
       :id => json_hash["id"],


### PR DESCRIPTION
When parsing the config file, if libvirt_use_sudo is present and set to
a string that represents a boolean, then the yaml parser will not give
us a String object, but something from TrueClass or FalseClass.

Since we need a string later on (otherwise, the tests on the variable
always fails, even if libvirt_use_sudo is true), convert this to a
string.
