### PR TITLE
Fixes kytoon ssh broken by thor 0.17.0

### DIFF
--- a/lib/kytoon/thor_tasks.rb
+++ b/lib/kytoon/thor_tasks.rb
@@ -79,7 +79,7 @@ class ThorTasks < Thor
   desc "ssh", "SSH into a group."
   method_options :group_id => :string
   method_options :group_type => :string
-  def ssh(options=(options or {}))
+  def ssh(*)
     begin
       ServerGroup.init(options[:group_type])
       args=ARGV[1, ARGV.length].join(" ")


### PR DESCRIPTION
Thor interpreted ssh(opt = (opt or {})) as a task that doesn't
accept any parameter. This is fixed by making ssh(*) which
hints to thor that the task accepts multiple arguments
